### PR TITLE
CI build

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,7 +10,8 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: mesytec-mvlc-clone
-      run: git clone https://github.com/flueke/mesytec-mvlc
+      # run: git clone https://github.com/flueke/mesytec-mvlc
+      run: git clone -b no_extractShift https://github.com/inkdot7/mesytec-mvlc
     - name: mesytec-mvlc-configure
       run: cd mesytec-mvlc && mkdir build && cd build && cmake -DCMAKE_CXX_FLAGS="-Werror" ..
     - name: mesytec-mvlc-build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,23 @@
+name: C/C++ CI
+
+on: [push]
+
+jobs:
+  build-ubuntu:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: mesytec-mvlc-clone
+      run: git clone https://github.com/flueke/mesytec-mvlc
+    - name: mesytec-mvlc-configure
+      run: cd mesytec-mvlc && mkdir build && cd build && cmake -DCMAKE_CXX_FLAGS="-Werror" ..
+    - name: mesytec-mvlc-build
+      run: cd mesytec-mvlc && cmake --build build
+    - name: mesytec-mvlc-test
+      run: cd mesytec-mvlc && cd build && ctest
+    - name: build
+      run: export MVLC_DIR=`pwd`/mesytec-mvlc && make
+    - name: example
+      run: export MVLC_DIR=`pwd`/mesytec-mvlc && make -C example


### PR DESCRIPTION
Adds a CI build, see

https://github.com/inkdot7/mvlcc/actions

had to clone a forked mesytec-mvlc, as the upstream has an unmerged pull request to fix an issue.