### PR TITLE
mvlcc_make_mvlc()

### DIFF
--- a/include/mvlcc_wrap.h
+++ b/include/mvlcc_wrap.h
@@ -23,7 +23,7 @@ typedef enum {
 } mvlcc_data_width_t;
 
 mvlcc_t mvlcc_make_mvlc_from_crate_config(const char *);
-mvlcc_t mvlcc_make_mvlc_eth(const char *);
+mvlcc_t mvlcc_make_mvlc_eth(const char *host);
 mvlcc_t mvlcc_make_mvlc_usb_from_index(int index);
 mvlcc_t mvlcc_make_mvlc_usb_from_serial(const char *serial);
 void mvlcc_free_mvlc(mvlcc_t a_mvlc);

--- a/include/mvlcc_wrap.h
+++ b/include/mvlcc_wrap.h
@@ -23,6 +23,7 @@ typedef enum {
 } mvlcc_data_width_t;
 
 mvlcc_t mvlcc_make_mvlc_from_crate_config(const char *);
+mvlcc_t mvlcc_make_mvlc(const char *urlstr);
 mvlcc_t mvlcc_make_mvlc_eth(const char *host);
 mvlcc_t mvlcc_make_mvlc_usb_from_index(int index);
 mvlcc_t mvlcc_make_mvlc_usb_from_serial(const char *serial);

--- a/src/mvlcc_wrap.cpp
+++ b/src/mvlcc_wrap.cpp
@@ -33,10 +33,10 @@ mvlcc_make_mvlc_from_crate_config(const char *configname)
 }
 
 mvlcc_t
-mvlcc_make_mvlc_eth(const char *hostname)
+mvlcc_make_mvlc_eth(const char *host)
 {
 	auto m = new mvlcc();
-	m->mvlc = make_mvlc_eth(hostname);
+	m->mvlc = make_mvlc_eth(host);
 	m->ethernet = dynamic_cast<eth::MVLC_ETH_Interface *>(
 	    m->mvlc.getImpl());
 	return m;

--- a/src/mvlcc_wrap.cpp
+++ b/src/mvlcc_wrap.cpp
@@ -33,7 +33,16 @@ mvlcc_make_mvlc_from_crate_config(const char *configname)
 }
 
 mvlcc_t
-mvlcc_make_mvlc_eth(const char *host)
+mvlcc_make_mvlc(const char *urlstr)
+{
+	auto m = new mvlcc();
+	m->mvlc = make_mvlc(urlstr);
+	m->ethernet = dynamic_cast<eth::MVLC_ETH_Interface *>(
+	    m->mvlc.getImpl());
+	return m;
+}
+
+mvlcc_t mvlcc_make_mvlc_eth(const char *host)
 {
 	auto m = new mvlcc();
 	m->mvlc = make_mvlc_eth(host);


### PR DESCRIPTION
There is a mesytec-mvlc function which can be used both for ethernet and usb connections.
Provide also this.  Perhaps later it is enough to only provide this...
Patch to actually use it in the example coming later.  Needs some test first.