### PR TITLE
mvlcc_vme_block_read() and parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+build_cc_x86_64-linux-gnu_12/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 build_cc_x86_64-linux-gnu_12/
+example/*.o
+example/test
+example/test2
+example/test3
+example/test4
+*.sw?

--- a/bin/mvlcc-config.sh
+++ b/bin/mvlcc-config.sh
@@ -47,7 +47,7 @@ CFLAGS="$CFLAGS -I ${MVLCC_DIR}/include/"
 LDFLAGS="$LDFLAGS"
 # The platform support libs ($LIBS from config) must be last
 LIBSDIR="-L${MVLCC_DIR}/${LIB_DIR} -L${MVLC_DIR}/build/"
-LIBS="$LIBS -lmvlcc -lmesytec-mvlc \
+LIBS="$LIBS -lmvlcc -lmesytec-mvlc -lstdc++ \
     -Wl,-rpath=${MVLC_DIR}/build/"
 
 while [ $# -gt 0 ]; do
@@ -64,7 +64,6 @@ while [ $# -gt 0 ]; do
 	--libs)
 	    OUT="$OUT ${LIBSDIR}"
 	    OUT="$OUT ${LIBS}"
-	    OUT="$OUT -lstdc++"
 	    ;;
 	--help|-h)
 	    usage 0

--- a/include/mvlcc_wrap.h
+++ b/include/mvlcc_wrap.h
@@ -50,9 +50,9 @@ struct MvlccBlockReadParams
     int swap: 1;  /* if true swaps the two 32-bit words for 64-bit MBLT reads */
 };
 
-/* bufferInSize and bufferOutSize are in units of 32-bit words */
-int mvlcc_vme_block_read(mvlcc_t a_mvlc, uint32_t address, uint32_t *buffer, size_t bufferInSize,
-  size_t *bufferOutSize, struct MvlccBlockReadParams params);
+/* sizeIn and sizeOut in units of 32-bit words */
+int mvlcc_vme_block_read(mvlcc_t a_mvlc, uint32_t address, uint32_t *buffer, size_t sizeIn,
+  size_t *sizeOut, struct MvlccBlockReadParams params);
 
 /* spdlog level names: error, warn, info, debug, trace */
 void mvlcc_set_global_log_level(const char *levelName);

--- a/include/mvlcc_wrap.h
+++ b/include/mvlcc_wrap.h
@@ -2,6 +2,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h> // for FILE
 
 typedef void *mvlcc_t;
 
@@ -45,6 +46,10 @@ int mvlcc_is_usb(mvlcc_t a_mvlc);
 
 /* spdlog level names: error, warn, info, debug, trace */
 void mvlcc_set_global_log_level(const char *levelName);
+
+/* Prints stack transaction retry counters and some more stats related to direct
+ * cmd execution. */
+void mvlcc_print_mvlc_cmd_counters(FILE *out, mvlcc_t a_mvlc);
 
 /* (flueke): Returns a pointer to the internal MVLC object.
  * Used in the daq1 hack.

--- a/include/mvlcc_wrap.h
+++ b/include/mvlcc_wrap.h
@@ -46,8 +46,8 @@ int mvlcc_is_usb(mvlcc_t a_mvlc);
 struct MvlccBlockReadParams
 {
     uint8_t amod; /* amod, must be a valid VME block amod */
-    int fifo: 1;  /* if true the read address is not incremented */
-    int swap: 1;  /* if true swaps the two 32-bit words for 64-bit MBLT reads */
+    int fifo;  /* if true the read address is not incremented */
+    int swap;  /* if true swaps the two 32-bit words for 64-bit MBLT reads */
 };
 
 /* sizeIn and sizeOut in units of 32-bit words */

--- a/include/mvlcc_wrap.h
+++ b/include/mvlcc_wrap.h
@@ -50,7 +50,14 @@ struct MvlccBlockReadParams
     int swap;  /* if true swaps the two 32-bit words for 64-bit MBLT reads */
 };
 
-/* sizeIn and sizeOut in units of 32-bit words */
+/* Directly executed block read. Uses MVLCs command pipe which has a smaller
+ * buffer than the readout pipe. Not recommended to be used for real DAQs!
+ * Writes the raw blockread contents, stripped of any MVLC framing, into buffer.
+ *
+ * Returns 0 on success, non-zero otherwise.
+ * The number of words copied into the output buffer is returned in sizeOut.
+ * sizeIn and sizeOut in units of 32-bit words.
+ */
 int mvlcc_vme_block_read(mvlcc_t a_mvlc, uint32_t address, uint32_t *buffer, size_t sizeIn,
   size_t *sizeOut, struct MvlccBlockReadParams params);
 

--- a/include/mvlcc_wrap.h
+++ b/include/mvlcc_wrap.h
@@ -46,6 +46,11 @@ int mvlcc_is_usb(mvlcc_t a_mvlc);
 /* spdlog level names: error, warn, info, debug, trace */
 void mvlcc_set_global_log_level(const char *levelName);
 
+/* (flueke): Returns a pointer to the internal MVLC object.
+ * Used in the daq1 hack.
+ */
+void *mvlcc_get_mvlc_object(mvlcc_t a_mvlc);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/mvlcc_wrap.h
+++ b/include/mvlcc_wrap.h
@@ -40,6 +40,7 @@ int mvlcc_register_write(mvlcc_t a_mvlc, uint16_t address, uint32_t value);
 const char *mvlcc_strerror(int errnum);
 int mvlcc_is_mvlc_valid(mvlcc_t a_mvlc);
 int mvlcc_is_ethernet(mvlcc_t a_mvlc);
+int mvlcc_is_usb(mvlcc_t a_mvlc);
 
 
 /* spdlog level names: error, warn, info, debug, trace */

--- a/include/mvlcc_wrap.h
+++ b/include/mvlcc_wrap.h
@@ -43,6 +43,16 @@ int mvlcc_is_mvlc_valid(mvlcc_t a_mvlc);
 int mvlcc_is_ethernet(mvlcc_t a_mvlc);
 int mvlcc_is_usb(mvlcc_t a_mvlc);
 
+struct MvlccBlockReadParams
+{
+    uint8_t amod; /* amod, must be a valid VME block amod */
+    int fifo: 1;  /* if true the read address is not incremented */
+    int swap: 1;  /* if true swaps the two 32-bit words for 64-bit MBLT reads */
+};
+
+/* bufferInSize and bufferOutSize are in units of 32-bit words */
+int mvlcc_vme_block_read(mvlcc_t a_mvlc, uint32_t address, uint32_t *buffer, size_t bufferInSize,
+  size_t *bufferOutSize, struct MvlccBlockReadParams params);
 
 /* spdlog level names: error, warn, info, debug, trace */
 void mvlcc_set_global_log_level(const char *levelName);

--- a/src/mvlcc_wrap.cpp
+++ b/src/mvlcc_wrap.cpp
@@ -381,6 +381,22 @@ void mvlcc_set_global_log_level(const char *levelName)
 	set_global_log_level(spdlog::level::from_str(levelName));
 }
 
+void mvlcc_print_mvlc_cmd_counters(FILE *out, mvlcc_t a_mvlc)
+{
+	assert(out);
+	assert(a_mvlc);
+
+	auto m = static_cast<struct mvlcc *>(a_mvlc);
+	auto &mvlc = m->mvlc;
+	auto counters = mvlc.getCmdPipeCounters();
+
+	fprintf(out, fmt::format("super txs: totalTxs={}, retries={}, cmd txs: totalTxs={}, retries={}, execRequestsLost={}, execResponsesLost={}",
+		counters.superTransactionCount, counters.superTransactionRetries,
+		counters.stackTransactionCount, counters.stackTransactionRetries,
+		counters.stackExecRequestsLost, counters.stackExecResponsesLost).c_str());
+
+}
+
 void *mvlcc_get_mvlc_object(mvlcc_t a_mvlc)
 {
 	assert(a_mvlc);

--- a/src/mvlcc_wrap.cpp
+++ b/src/mvlcc_wrap.cpp
@@ -441,9 +441,10 @@ int post_process_blt_data(const std::vector<u32> &src, util::span<uint32_t> dest
 {
 	// Input structure from directly executed block reads:
 	//  0xF3  outer stack frame header
-	//    0x??  reference word that was added by the MVLC library code. Same as a //  "marker" command in a readout script.
+	//    0x??  reference word that was added by the MVLC library code. Same as a "marker" command in a readout script.
 	//    0xF5  first block read frame header.
-	//   [0xF9  optional stack continuation frames]
+	// [0xF9  optional stack continuation frames]
+	//   [0xF5  optional continuations of the block read frame]
 
 	if (src.size() < 3)
 		return -1;

--- a/src/mvlcc_wrap.cpp
+++ b/src/mvlcc_wrap.cpp
@@ -11,6 +11,7 @@ struct mvlcc
 	mesytec::mvlc::CrateConfig config;
 	mesytec::mvlc::MVLC mvlc;
 	mesytec::mvlc::eth::MVLC_ETH_Interface *ethernet;
+	mesytec::mvlc::usb::MVLC_USB_Interface *usb;
 };
 
 int readout_eth(eth::MVLC_ETH_Interface *a_eth, uint8_t *a_buffer,
@@ -22,6 +23,7 @@ static mvlcc_t make_mvlcc(const MVLC &mvlc, const CrateConfig &crateConfig = {})
 	auto ret = std::make_unique<mvlcc>();
 	ret->mvlc = mvlc;
 	ret->ethernet = dynamic_cast<eth::MVLC_ETH_Interface *>(ret->mvlc.getImpl());
+	ret->usb = dynamic_cast<usb::MVLC_USB_Interface *>(ret->mvlc.getImpl());
 	ret->config = crateConfig;
 	return ret.release();
 }
@@ -366,6 +368,12 @@ int mvlcc_is_ethernet(mvlcc_t a_mvlc)
 {
 	auto m = static_cast<struct mvlcc *>(a_mvlc);
 	return m->ethernet != nullptr;
+}
+
+int mvlcc_is_usb(mvlcc_t a_mvlc)
+{
+	auto m = static_cast<struct mvlcc *>(a_mvlc);
+	return m->usb != nullptr;
 }
 
 void mvlcc_set_global_log_level(const char *levelName)

--- a/src/mvlcc_wrap.cpp
+++ b/src/mvlcc_wrap.cpp
@@ -437,12 +437,14 @@ struct BltPostProcessState
 	FrameParseState curBlockFrame;
 };
 
-ssize_t post_process_blt_data(const std::vector<u32> &src, util::span<uint32_t> dest)
+int post_process_blt_data(const std::vector<u32> &src, util::span<uint32_t> dest, size_t &wordsCopied)
 {
 	// Input structure from directly executed block reads:
 	//  0xF3  outer stack frame header
-	//  0x??  reference word that was added by the MVLC library code. Same as a //  "marker" command in a readout script.
-	//  0xF5  first block read frame header.
+	//    0x??  reference word that was added by the MVLC library code. Same as a //  "marker" command in a readout script.
+	//    0xF5  first block read frame header.
+	//   [0xF9  optional stack continuation frames]
+
 	if (src.size() < 3)
 		return -1;
 
@@ -455,21 +457,24 @@ ssize_t post_process_blt_data(const std::vector<u32> &src, util::span<uint32_t> 
 
 	const auto outEnd = std::end(dest);
 	auto outIter = std::begin(dest);
+	wordsCopied = 0u;
 
 	try
 	{
 
 		while (!input.empty())
 		{
-			if (extract_frame_info(state.curStackFrame.header).type != frame_headers::StackFrame)
+			if (auto stackFrameType = get_frame_type(state.curStackFrame.header);
+				stackFrameType != frame_headers::StackFrame && stackFrameType != frame_headers::StackContinuation)
 			{
-				// The outer frame is not a stack frame.
+				spdlog::error("post_process_blt_data(): expected StackFrame or StackContinuation frame header, got 0x{:08X}", state.curStackFrame.header);
 				return -1;
 			}
 
-			if (extract_frame_info(state.curBlockFrame.header).type != frame_headers::BlockRead)
+			if (auto blockFrameType = get_frame_type(state.curBlockFrame.header);
+				blockFrameType != frame_headers::BlockRead)
 			{
-				// The inner frame is not a block frame.
+				spdlog::error("post_process_blt_data(): expected BlockRead frame header, got 0x{:08X}", state.curBlockFrame.header);
 				return -1;
 			}
 
@@ -477,6 +482,7 @@ ssize_t post_process_blt_data(const std::vector<u32> &src, util::span<uint32_t> 
 			{
 				*outIter++ = consume_one(input);
 				state.curBlockFrame.consumeWord();
+				++wordsCopied;
 			}
 
 			// The inner block frame does not have the continue flag set, so we're done.
@@ -484,7 +490,10 @@ ssize_t post_process_blt_data(const std::vector<u32> &src, util::span<uint32_t> 
 				break;
 
 			if (input.size() < 2) // need at least two words: outer 0xF9 StackContinuation and inner 0xF5 BlockRead
+			{
+				spdlog::error("post_process_blt_data(): input.size()={} (less than 2) -> result=-1", input.size());
 				return -1;
+			}
 
 			state.curStackFrame = FrameParseState(consume_one(input));
 			state.curBlockFrame	= FrameParseState(consume_one(input));
@@ -495,7 +504,9 @@ ssize_t post_process_blt_data(const std::vector<u32> &src, util::span<uint32_t> 
 		return -1; // should not happen, data format corrupted
 	}
 
-	return std::distance(std::begin(dest), outIter);
+	spdlog::trace("post_process_blt_data(): wordsCopied={}", wordsCopied);
+
+	return 0;
 }
 
 } /* End namespace. */
@@ -510,7 +521,6 @@ int mvlcc_vme_block_read(mvlcc_t a_mvlc, uint32_t address, uint32_t *buffer, siz
 	auto &mvlc = m->mvlc;
 
 	const u16 maxTransfers = sizeIn / (vme_amods::is_mblt_mode(params.amod) ? 2 : 1);
-	//const u16 maxTransfers = std::numeric_limits<u16>::max();
 	std::error_code ec;
 
 	m->bltWorkBuffer.clear();
@@ -524,7 +534,7 @@ int mvlcc_vme_block_read(mvlcc_t a_mvlc, uint32_t address, uint32_t *buffer, siz
 		ec = mvlc.vmeBlockRead(address, params.amod, maxTransfers, m->bltWorkBuffer, params.fifo);
 	}
 
-	log_buffer(default_logger(), spdlog::level::info, m->bltWorkBuffer,
+	log_buffer(default_logger(), spdlog::level::debug, m->bltWorkBuffer,
 		fmt::format("vmeBlockRead() (result={}, {}) raw data", ec.value(), ec.message()), 10);
 
 	*sizeOut = 0;
@@ -532,20 +542,15 @@ int mvlcc_vme_block_read(mvlcc_t a_mvlc, uint32_t address, uint32_t *buffer, siz
 	if (!ec)
 	{
 		util::span<uint32_t> dest(buffer, sizeIn);
-		ssize_t r = post_process_blt_data(m->bltWorkBuffer, dest);
-		if (r >= 0)
-			*sizeOut = r;
-		else
+
+		if (post_process_blt_data(m->bltWorkBuffer, dest, *sizeOut) != 0)
 		{
-			*sizeOut = 0;
-			return -r;
+			spdlog::warn("post_process_blt_data() failed, wordsCopied={}", *sizeOut);
 		}
 	}
 
-	log_buffer(default_logger(), spdlog::level::info, std::basic_string_view<u32>(buffer, *sizeOut),
+	log_buffer(default_logger(), spdlog::level::debug, std::basic_string_view<u32>(buffer, *sizeOut),
 		fmt::format("vmeBlockRead() (result={}, {}) post processed data", ec.value(), ec.message()), 10);
-
-	//buffer[0] = 0xdeadbeef;
 
 	return ec.value();
 }

--- a/src/mvlcc_wrap.cpp
+++ b/src/mvlcc_wrap.cpp
@@ -390,10 +390,13 @@ void mvlcc_print_mvlc_cmd_counters(FILE *out, mvlcc_t a_mvlc)
 	auto &mvlc = m->mvlc;
 	auto counters = mvlc.getCmdPipeCounters();
 
-	fprintf(out, fmt::format("super txs: totalTxs={}, retries={}, cmd txs: totalTxs={}, retries={}, execRequestsLost={}, execResponsesLost={}",
-		counters.superTransactionCount, counters.superTransactionRetries,
-		counters.stackTransactionCount, counters.stackTransactionRetries,
-		counters.stackExecRequestsLost, counters.stackExecResponsesLost).c_str());
+	fprintf(out, "super txs: totalTxs=%lu, retries=%lu, cmd txs: totalTxs=%lu, retries=%lu, execRequestsLost=%lu, execResponsesLost=%lu",
+		(unsigned long) counters.superTransactionCount,
+		(unsigned long) counters.superTransactionRetries,
+		(unsigned long) counters.stackTransactionCount,
+		(unsigned long) counters.stackTransactionRetries,
+		(unsigned long) counters.stackExecRequestsLost,
+		(unsigned long) counters.stackExecResponsesLost);
 
 }
 

--- a/src/mvlcc_wrap.cpp
+++ b/src/mvlcc_wrap.cpp
@@ -17,6 +17,15 @@ int readout_eth(eth::MVLC_ETH_Interface *a_eth, uint8_t *a_buffer,
     size_t *bytes_transferred);
 int send_empty_request(MVLC *a_mvlc);
 
+static mvlcc_t make_mvlcc(const MVLC &mvlc, const CrateConfig &crateConfig = {})
+{
+	auto ret = std::make_unique<mvlcc>();
+	ret->mvlc = mvlc;
+	ret->ethernet = dynamic_cast<eth::MVLC_ETH_Interface *>(ret->mvlc.getImpl());
+	ret->config = crateConfig;
+	return ret.release();
+}
+
 mvlcc_t
 mvlcc_make_mvlc_from_crate_config(const char *configname)
 {
@@ -35,11 +44,7 @@ mvlcc_make_mvlc_from_crate_config(const char *configname)
 mvlcc_t
 mvlcc_make_mvlc(const char *urlstr)
 {
-	auto m = new mvlcc();
-	m->mvlc = make_mvlc(urlstr);
-	m->ethernet = dynamic_cast<eth::MVLC_ETH_Interface *>(
-	    m->mvlc.getImpl());
-	return m;
+	return make_mvlcc(make_mvlc(urlstr));
 }
 
 mvlcc_t mvlcc_make_mvlc_eth(const char *host)

--- a/src/mvlcc_wrap.cpp
+++ b/src/mvlcc_wrap.cpp
@@ -380,3 +380,11 @@ void mvlcc_set_global_log_level(const char *levelName)
 {
 	set_global_log_level(spdlog::level::from_str(levelName));
 }
+
+void *mvlcc_get_mvlc_object(mvlcc_t a_mvlc)
+{
+	assert(a_mvlc);
+
+	auto m = static_cast<struct mvlcc *>(a_mvlc);
+	return &m->mvlc;
+}

--- a/src/mvlcc_wrap.cpp
+++ b/src/mvlcc_wrap.cpp
@@ -391,8 +391,6 @@ int mvlcc_vme_block_read(mvlcc_t a_mvlc, uint32_t address, uint32_t *buffer, siz
 
 	std::error_code ec;
 
-	assert(!params.swap); // TODO: implement swap
-
 	//if (!params.swap)
 		ec = mvlc.vmeBlockRead(address, params.amod, maxTransfers, dest, params.fifo);
 

--- a/src/mvlcc_wrap.cpp
+++ b/src/mvlcc_wrap.cpp
@@ -376,35 +376,30 @@ int mvlcc_is_usb(mvlcc_t a_mvlc)
 	return m->usb != nullptr;
 }
 
-int mvlcc_vme_block_read(mvlcc_t a_mvlc, uint32_t address, uint32_t *buffer, size_t bufferInSize,
-  size_t *bufferOutSize, struct MvlccBlockReadParams params)
+int mvlcc_vme_block_read(mvlcc_t a_mvlc, uint32_t address, uint32_t *buffer, size_t sizeIn,
+  size_t *sizeOut, struct MvlccBlockReadParams params)
 {
 	assert(buffer);
-	assert(bufferOutSize);
+	assert(sizeOut);
 
 	auto m = static_cast<struct mvlcc *>(a_mvlc);
 	auto &mvlc = m->mvlc;
 
-	const u16 maxTransfers = bufferInSize / (vme_amods::is_mblt_mode(params.amod) ? 2 : 1);
+	const u16 maxTransfers = sizeIn / (vme_amods::is_mblt_mode(params.amod) ? 2 : 1);
 
-	std::vector<u32> localData;
-	localData.reserve(bufferInSize/sizeof(u32));
+	util::span<uint32_t> dest(buffer, sizeIn);
 
 	std::error_code ec;
 
-	if (!params.swap)
-		ec = mvlc.vmeBlockRead(address, params.amod, maxTransfers, localData, params.fifo);
-	else
-		ec = mvlc.vmeBlockReadSwapped(address, params.amod, maxTransfers, localData, params.fifo);
+	assert(!params.swap); // TODO: implement swap
 
-	if (ec)
-		return ec.value();
+	//if (!params.swap)
+		ec = mvlc.vmeBlockRead(address, params.amod, maxTransfers, dest, params.fifo);
 
-	const auto end = std::min(localData.begin() + bufferInSize, localData.end());
-	std::copy(localData.begin(), end, buffer);
-	*bufferOutSize = end - localData.begin();
+	log_buffer(default_logger(), spdlog::level::info, dest, "vmeBlockRead()");
 
-	return 0;
+	*sizeOut = dest.size();
+	return ec.value();
 }
 
 void mvlcc_set_global_log_level(const char *levelName)

--- a/src/mvlcc_wrap.cpp
+++ b/src/mvlcc_wrap.cpp
@@ -376,6 +376,37 @@ int mvlcc_is_usb(mvlcc_t a_mvlc)
 	return m->usb != nullptr;
 }
 
+int mvlcc_vme_block_read(mvlcc_t a_mvlc, uint32_t address, uint32_t *buffer, size_t bufferInSize,
+  size_t *bufferOutSize, struct MvlccBlockReadParams params)
+{
+	assert(buffer);
+	assert(bufferOutSize);
+
+	auto m = static_cast<struct mvlcc *>(a_mvlc);
+	auto &mvlc = m->mvlc;
+
+	const u16 maxTransfers = bufferInSize / (vme_amods::is_mblt_mode(params.amod) ? 2 : 1);
+
+	std::vector<u32> localData;
+	localData.reserve(bufferInSize/sizeof(u32));
+
+	std::error_code ec;
+
+	if (!params.swap)
+		ec = mvlc.vmeBlockRead(address, params.amod, maxTransfers, localData, params.fifo);
+	else
+		ec = mvlc.vmeBlockReadSwapped(address, params.amod, maxTransfers, localData, params.fifo);
+
+	if (ec)
+		return ec.value();
+
+	const auto end = std::min(localData.begin() + bufferInSize, localData.end());
+	std::copy(localData.begin(), end, buffer);
+	*bufferOutSize = end - localData.begin();
+
+	return 0;
+}
+
 void mvlcc_set_global_log_level(const char *levelName)
 {
 	set_global_log_level(spdlog::level::from_str(levelName));

--- a/src/mvlcc_wrap.cpp
+++ b/src/mvlcc_wrap.cpp
@@ -388,7 +388,7 @@ void mvlcc_print_mvlc_cmd_counters(FILE *out, mvlcc_t a_mvlc)
 
 	auto m = static_cast<struct mvlcc *>(a_mvlc);
 	auto &mvlc = m->mvlc;
-	auto counters = mvlc.getCmdPipeCounters();
+	const auto counters = mvlc.getCmdPipeCounters();
 
 	fprintf(out, "super txs: totalTxs=%lu, retries=%lu, cmd txs: totalTxs=%lu, retries=%lu, execRequestsLost=%lu, execResponsesLost=%lu",
 		(unsigned long) counters.superTransactionCount,
@@ -398,6 +398,11 @@ void mvlcc_print_mvlc_cmd_counters(FILE *out, mvlcc_t a_mvlc)
 		(unsigned long) counters.stackExecRequestsLost,
 		(unsigned long) counters.stackExecResponsesLost);
 
+	if (m->ethernet)
+	{
+		const auto cmdStats = m->ethernet->getPipeStats()[0];
+		fprintf(out, fmt::format(", eth: lostPackets={}", cmdStats.lostPackets).c_str());
+	}
 }
 
 void *mvlcc_get_mvlc_object(mvlcc_t a_mvlc)

--- a/src/mvlcc_wrap.cpp
+++ b/src/mvlcc_wrap.cpp
@@ -391,12 +391,16 @@ int mvlcc_vme_block_read(mvlcc_t a_mvlc, uint32_t address, uint32_t *buffer, siz
 
 	std::error_code ec;
 
-	if (!params.swap)
-		ec = mvlc.vmeBlockRead(address, params.amod, maxTransfers, dest, params.fifo);
-	else
+	if (vme_amods::is_mblt_mode(params.amod) && params.swap)
+	{
 		ec = mvlc.vmeBlockReadSwapped(address, params.amod, maxTransfers, dest, params.fifo);
+	}
+	else
+	{
+		ec = mvlc.vmeBlockRead(address, params.amod, maxTransfers, dest, params.fifo);
+	}
 
-	log_buffer(default_logger(), spdlog::level::info, dest, "vmeBlockRead()");
+	log_buffer(default_logger(), spdlog::level::debug, dest, "vmeBlockRead()");
 
 	*sizeOut = dest.size();
 	return ec.value();

--- a/src/mvlcc_wrap.cpp
+++ b/src/mvlcc_wrap.cpp
@@ -103,7 +103,7 @@ mvlcc_stop(mvlcc_t a_mvlc)
 	auto ec = disable_daq_mode_and_triggers(m->mvlc);
 	if (ec) {
 		printf("'%s'\n", ec.message().c_str());
-		abort();
+		return 1;
 	}
 
 	return 0;
@@ -132,7 +132,7 @@ mvlcc_init_readout(mvlcc_t a_mvlc)
 	rc = result.ec.value();
 	if (rc != 0) {
 		printf("init_readout: '%s'\n", result.ec.message().c_str());
-		abort();
+		return rc;
 	}
 
 	m->ethernet->resetPipeAndChannelStats();
@@ -142,7 +142,7 @@ mvlcc_init_readout(mvlcc_t a_mvlc)
 	auto ec = setup_readout_triggers(m->mvlc, m->config.triggers);
 	if (ec) {
 		printf("setup_readout_triggers: '%s'\n", ec.message().c_str());
-		abort();
+		return ec.value();
 	}
 
 	return rc;
@@ -165,7 +165,7 @@ send_empty_request(MVLC *a_mvlc)
 
 	if (ec) {
 		printf("Failure writing empty request.\n");
-		abort();
+		return ec.value();
 	}
 
 	return 0;
@@ -190,20 +190,20 @@ readout_eth(eth::MVLC_ETH_Interface *a_eth, uint8_t *a_buffer,
 		auto ec = result.ec;
 		if (ec == ErrorType::ConnectionError) {
 			printf("Connection error.\n");
-			abort();
+			return ec.value();
 		}
 		if (ec == MVLCErrorCode::ShortRead) {
 			printf("Short read.\n");
-			abort();
+			return ec.value();
 		}
 		rc = ec.value();
 		if (rc != 0) {
 			printf("'%s'\n", result.ec.message().c_str());
-			abort();
+			return ec.value();
 		}
 		if (result.leftoverBytes()) {
 			printf("Leftover bytes. Bailing out!\n");
-			abort();
+			return ec.value();
 		}
 		buffer += result.bytesTransferred;
 		bytes_free -= result.bytesTransferred;
@@ -234,7 +234,7 @@ mvlcc_readout_eth(mvlcc_t a_mvlc, uint8_t **a_buffer, size_t bytes_free)
 	rc = readout_eth(m->ethernet, buffer, bytes_free, &bytes_transferred);
 	if (rc != 0) {
 		printf("Failure in readout_eth %d\n", rc);
-		abort();
+		return rc;
 	}
 
 	printf("Transferred %lu bytes\n", bytes_transferred);
@@ -295,7 +295,7 @@ mvlcc_single_vme_read(mvlcc_t a_mvlc, uint32_t address, uint32_t * value, uint8_
   rc = ec.value();
   if (rc != 0) {
     printf("Failure in vmeRead %d (%s)\n", rc, ec.message().c_str());
-    abort();
+	return rc;
   }
 
   // printf("\nvalue = %x\n", *value);
@@ -318,7 +318,7 @@ mvlcc_single_vme_write(mvlcc_t a_mvlc, uint32_t address, uint32_t value, uint8_t
   rc = ec.value();
   if (rc != 0) {
     printf("Failure in vmeWrite %d\n", rc);
-    abort();
+	return rc;
   }
   //
   return rc;

--- a/src/mvlcc_wrap.cpp
+++ b/src/mvlcc_wrap.cpp
@@ -203,7 +203,7 @@ readout_eth(eth::MVLC_ETH_Interface *a_eth, uint8_t *a_buffer,
 		}
 		if (result.leftoverBytes()) {
 			printf("Leftover bytes. Bailing out!\n");
-			return ec.value();
+			return 1; /* Cannot use ec.value, is 0. */
 		}
 		buffer += result.bytesTransferred;
 		bytes_free -= result.bytesTransferred;

--- a/src/mvlcc_wrap.cpp
+++ b/src/mvlcc_wrap.cpp
@@ -387,10 +387,10 @@ int mvlcc_vme_block_read(mvlcc_t a_mvlc, uint32_t address, uint32_t *buffer, siz
 	auto &mvlc = m->mvlc;
 
 	const u16 maxTransfers = sizeIn / (vme_amods::is_mblt_mode(params.amod) ? 2 : 1);
+	//const u16 maxTransfers = std::numeric_limits<u16>::max();
 	std::error_code ec;
 
 	m->bltWorkBuffer.clear();
-	m->bltWorkBuffer.reserve(maxTransfers/sizeof(u32));
 
 	if (vme_amods::is_mblt_mode(params.amod) && params.swap)
 	{
@@ -421,6 +421,8 @@ int mvlcc_vme_block_read(mvlcc_t a_mvlc, uint32_t address, uint32_t *buffer, siz
 
 	log_buffer(default_logger(), spdlog::level::info, std::basic_string_view<u32>(buffer, *sizeOut),
 		fmt::format("vmeBlockRead() (result={}, {}) post processed data", ec.value(), ec.message()), 10);
+
+	//buffer[0] = 0xdeadbeef;
 
 	return ec.value();
 }

--- a/src/mvlcc_wrap.cpp
+++ b/src/mvlcc_wrap.cpp
@@ -391,8 +391,10 @@ int mvlcc_vme_block_read(mvlcc_t a_mvlc, uint32_t address, uint32_t *buffer, siz
 
 	std::error_code ec;
 
-	//if (!params.swap)
+	if (!params.swap)
 		ec = mvlc.vmeBlockRead(address, params.amod, maxTransfers, dest, params.fifo);
+	else
+		ec = mvlc.vmeBlockReadSwapped(address, params.amod, maxTransfers, dest, params.fifo);
 
 	log_buffer(default_logger(), spdlog::level::info, dest, "vmeBlockRead()");
 

--- a/src/mvlcc_wrap.cpp
+++ b/src/mvlcc_wrap.cpp
@@ -76,6 +76,7 @@ void
 mvlcc_free_mvlc(mvlcc_t a_mvlc)
 {
 	auto m = static_cast<struct mvlcc *>(a_mvlc);
+	m->ethernet = nullptr;
 	delete m;
 }
 

--- a/src/mvlcc_wrap.cpp
+++ b/src/mvlcc_wrap.cpp
@@ -401,7 +401,8 @@ void mvlcc_print_mvlc_cmd_counters(FILE *out, mvlcc_t a_mvlc)
 	if (m->ethernet)
 	{
 		const auto cmdStats = m->ethernet->getPipeStats()[0];
-		fprintf(out, fmt::format(", eth: lostPackets={}", cmdStats.lostPackets).c_str());
+		fprintf(out, ", eth: lostPackets=%lu",
+			(unsigned long) cmdStats.lostPackets);
 	}
 }
 


### PR DESCRIPTION
These are the commits that add ``mvlcc_vme_block_read()` and associated parser.
The have been shuffled such that other changes are either before or after them.
Note: based on #17 , so consider that first.