### PR TITLE
sizeOut -> wordsOut in mvlcc_vme_block_read.

### DIFF
--- a/include/mvlcc_wrap.h
+++ b/include/mvlcc_wrap.h
@@ -55,11 +55,11 @@ struct MvlccBlockReadParams
  * Writes the raw blockread contents, stripped of any MVLC framing, into buffer.
  *
  * Returns 0 on success, non-zero otherwise.
- * The number of words copied into the output buffer is returned in sizeOut.
- * sizeIn and sizeOut in units of 32-bit words.
+ * The number of words copied into the output buffer is returned in wordsOut.
+ * sizeIn and wordsOut in units of 32-bit words.
  */
 int mvlcc_vme_block_read(mvlcc_t a_mvlc, uint32_t address, uint32_t *buffer, size_t sizeIn,
-  size_t *sizeOut, struct MvlccBlockReadParams params);
+  size_t *wordsOut, struct MvlccBlockReadParams params);
 
 /* spdlog level names: error, warn, info, debug, trace */
 void mvlcc_set_global_log_level(const char *levelName);

--- a/src/mvlcc_wrap.cpp
+++ b/src/mvlcc_wrap.cpp
@@ -513,10 +513,10 @@ int post_process_blt_data(const std::vector<u32> &src, util::span<uint32_t> dest
 } /* End namespace. */
 
 int mvlcc_vme_block_read(mvlcc_t a_mvlc, uint32_t address, uint32_t *buffer, size_t sizeIn,
-  size_t *sizeOut, struct MvlccBlockReadParams params)
+  size_t *wordsOut, struct MvlccBlockReadParams params)
 {
 	assert(buffer);
-	assert(sizeOut);
+	assert(wordsOut);
 
 	auto m = static_cast<struct mvlcc *>(a_mvlc);
 	auto &mvlc = m->mvlc;
@@ -538,19 +538,19 @@ int mvlcc_vme_block_read(mvlcc_t a_mvlc, uint32_t address, uint32_t *buffer, siz
 	log_buffer(default_logger(), spdlog::level::debug, m->bltWorkBuffer,
 		fmt::format("vmeBlockRead() (result={}, {}) raw data", ec.value(), ec.message()), 10);
 
-	*sizeOut = 0;
+	*wordsOut = 0;
 
 	if (!ec)
 	{
 		util::span<uint32_t> dest(buffer, sizeIn);
 
-		if (post_process_blt_data(m->bltWorkBuffer, dest, *sizeOut) != 0)
+		if (post_process_blt_data(m->bltWorkBuffer, dest, *wordsOut) != 0)
 		{
-			spdlog::warn("post_process_blt_data() failed, wordsCopied={}", *sizeOut);
+			spdlog::warn("post_process_blt_data() failed, wordsCopied={}", *wordsOut);
 		}
 	}
 
-	log_buffer(default_logger(), spdlog::level::debug, std::basic_string_view<u32>(buffer, *sizeOut),
+	log_buffer(default_logger(), spdlog::level::debug, std::basic_string_view<u32>(buffer, *wordsOut),
 		fmt::format("vmeBlockRead() (result={}, {}) post processed data", ec.value(), ec.message()), 10);
 
 	return ec.value();


### PR DESCRIPTION
Clarified output name from generic "size" to "words".